### PR TITLE
Add terminal-style React portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# Portfolio
+# Aadi Shah Portfolio
+
+This repository contains two versions of a terminal-style portfolio.
+
+## Simple Version
+
+Open `index.html` in your browser to try a minimal implementation. It accepts commands like `help`, `about`, `projects`, and `contact`.
+
+## React Version
+
+A full React app lives in the `my-portfolio` folder. To run it locally:
+
+```bash
+cd my-portfolio
+npm install
+npm start
+```
+
+Then open <http://localhost:3000> in your browser.
+
+The React version uses **react-terminal-ui** and Tailwind CSS to emulate a terminal interface. Update the files in `src/` to customize the commands and content.
+
+Due to the development environment, external data could not be fetched from **aadishah.org**. Update the placeholders with real information as needed.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,26 @@ This repository contains two versions of a terminal-style portfolio.
 
 Open `index.html` in your browser to try a minimal implementation. It accepts commands like `help`, `about`, `projects`, and `contact`.
 
+### macOS Quick Start
+
+If you're on macOS and want to preview the static version quickly, run:
+
+```bash
+./run_on_mac.sh
+```
+
+This script simply opens `index.html` in your default browser.
+
 ## React Version
 
 A full React app lives in the `my-portfolio` folder. To run it locally:
+
+First make sure [Node.js](https://nodejs.org/) is installed. On macOS you can
+use [Homebrew](https://brew.sh/):
+
+```bash
+brew install node
+```
 
 ```bash
 cd my-portfolio

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Aadi Shah Portfolio</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="terminal">
+    <pre id="output"></pre>
+    <div id="prompt"><span id="path">~/portfolio</span>$ <input id="input" autofocus></div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/my-portfolio/package.json
+++ b/my-portfolio/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "my-portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  },
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "react-scripts": "5.0.1",
+    "react-terminal-ui": "^1.4.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.0.0"
+  }
+}

--- a/my-portfolio/postcss.config.js
+++ b/my-portfolio/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/my-portfolio/public/index.html
+++ b/my-portfolio/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>My Portfolio</title>
+</head>
+<body class="bg-black text-green-400 font-mono">
+  <div id="root"></div>
+</body>
+</html>

--- a/my-portfolio/src/App.js
+++ b/my-portfolio/src/App.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import TerminalUI from './components/TerminalUI';
+
+function App() {
+  return (
+    <div className="min-h-screen p-4 bg-black text-green-400 font-mono">
+      <TerminalUI />
+    </div>
+  );
+}
+
+export default App;

--- a/my-portfolio/src/components/TerminalUI.js
+++ b/my-portfolio/src/components/TerminalUI.js
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Terminal, ColorMode } from 'react-terminal-ui';
+import 'react-terminal-ui/dist/index.css';
+import { runCommand } from '../terminalCommands';
+
+export default function TerminalUI() {
+  const [history, setHistory] = useState([]);
+
+  const handleInput = input => {
+    const output = runCommand(input);
+    setHistory([...history, { cmd: input, output }]);
+  };
+
+  return (
+    <div className="h-full">
+      <Terminal
+        history={history.map(h => [`$ ${h.cmd}`, h.output]).flat()}
+        prompt="$"
+        onInput={handleInput}
+        theme={ColorMode.Dark}
+        showControlButtons
+      />
+    </div>
+  );
+}

--- a/my-portfolio/src/index.css
+++ b/my-portfolio/src/index.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+.terminal-cursor {
+  animation: blink 1s step-end infinite;
+}

--- a/my-portfolio/src/index.js
+++ b/my-portfolio/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/my-portfolio/src/terminalCommands.js
+++ b/my-portfolio/src/terminalCommands.js
@@ -1,0 +1,29 @@
+const files = {
+  'about.txt': `
+Hi, I’m Aadi Shah.
+Welcome to my portfolio.
+`,
+  'projects.txt': `
+- Portfolio: This site
+- Project2: Description
+`,
+  'contact.txt': `
+Email: you@example.com
+GitHub: github.com/yourhandle
+`,
+};
+
+export function runCommand(cmd) {
+  const [base, ...args] = cmd.trim().split(' ');
+  switch (base) {
+    case 'help':
+      return 'Available commands: help, ls, cat <file>';
+    case 'ls':
+      return Object.keys(files).join('  ');
+    case 'cat':
+      if (!args[0]) return 'Usage: cat <filename>';
+      return files[args[0]] || `cat: ${args[0]}: No such file`;
+    default:
+      return `${base}: command not found`;
+  }
+}

--- a/my-portfolio/tailwind.config.js
+++ b/my-portfolio/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./src/**/*.{js,jsx,ts,tsx}",
+    "./public/index.html",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/run_on_mac.sh
+++ b/run_on_mac.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Simple script to open the minimal portfolio in the default browser on macOS
+# Usage: ./run_on_mac.sh
+open index.html

--- a/script.js
+++ b/script.js
@@ -1,0 +1,32 @@
+const output = document.getElementById('output');
+const input = document.getElementById('input');
+
+const commands = {
+  help: () => `Available commands: ${Object.keys(commands).join(', ')}`,
+  about: () => `Hi, I'm Aadi Shah. I'm building cool projects with JavaScript.`,
+  projects: () => `- portfolio-terminal\n- more coming soon`,
+  contact: () => `Email: aadi@example.com`
+};
+
+function handleCommand(cmd) {
+  const [name, ...args] = cmd.split(' ');
+  const fn = commands[name];
+  if (fn) return fn(args);
+  return `Command not found: ${name}`;
+}
+
+function appendOutput(text) {
+  output.textContent += text + '\n';
+}
+
+input.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    const command = input.value.trim();
+    appendOutput(`$ ${command}`);
+    appendOutput(handleCommand(command));
+    input.value = '';
+    window.scrollTo(0, document.body.scrollHeight);
+  }
+});
+
+appendOutput('Welcome to Aadi Shah\'s portfolio. Type "help" for commands.');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,23 @@
+body {
+  background-color: #000;
+  color: #0f0;
+  font-family: monospace;
+  margin: 0;
+  height: 100vh;
+}
+#terminal {
+  padding: 10px;
+}
+#output {
+  white-space: pre-wrap;
+}
+#prompt {
+  display: flex;
+}
+#input {
+  background: transparent;
+  border: none;
+  color: inherit;
+  outline: none;
+  width: 100%;
+}


### PR DESCRIPTION
## Summary
- document how to run the React app locally
- include CRA-style project in `my-portfolio`
- basic terminal commands with React Terminal UI

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68472eb9a7b0832cb19c9558c69d458d